### PR TITLE
Add DynamoDB docker container for use with Runner

### DIFF
--- a/eq.yml
+++ b/eq.yml
@@ -44,9 +44,14 @@ services:
       EQ_RABBITMQ_HOST: rabbit
       EQ_RABBITMQ_HOST_SECONDARY: rabbit
       EQ_SECRETS_FILE: docker-secrets.yml
+      EQ_ENVIRONMENT_PREFIX: dev
+      EQ_DYNAMODB_ENDPOINT: http://eq-survey-runner-dynamodb:8000
+      AWS_ACCESS_KEY_ID: dummy
+      AWS_SECRET_ACCESS_KEY: dummy
     depends_on:
       - eq-survey-runner-db
       - rabbit
+      - eq-survey-runner-dynamodb
     restart: always
     networks:
       - eq-runner
@@ -65,6 +70,14 @@ services:
       - eq-runner
     ports:
       - "8000:8000"
+
+  eq-survey-runner-dynamodb:
+    image: onsdigital/eq-docker-dynamodb:latest
+    restart: always
+    networks:
+      - eq-runner
+    ports:
+      - "6060:8000"
 
   eq-author:
     image: onsdigital/eq-author


### PR DESCRIPTION
Adds the DynamoDB container used by Survey Runner.

To Test:
change the image within the eq.yml file for eq-survey-runner to point to the Answers after submission branch
_image: onsdigital/eq-survey-runner:eq-204-responses-available-after-submission_

Then start all the eq services. A dynamoDB service should have been created. To check go to http://localhost:6060/shell/

Complete the **test_submitted_responses.json** and the Thank you page should show a link to view submitted responses which takes you to a new summary style page.
  
  