### PR TITLE
Optimise author api and publisher for production.

### DIFF
--- a/eq.yml
+++ b/eq.yml
@@ -87,6 +87,7 @@ services:
     image: onsdigital/eq-author-api
     environment:
       DB_CONNECTION_URI: postgres://postgres:mysecretpassword@eq-author-db:5432/postgres
+      NODE_ENV: production
     depends_on:
       - eq-author-db
     restart: always
@@ -99,6 +100,7 @@ services:
     image: onsdigital/eq-publisher
     environment:
       GRAPHQL_API_URL: http://eq-author-api:4000/graphql
+      NODE_ENV: production
     depends_on:
       - eq-author-api
     restart: always


### PR DESCRIPTION
### What is the context of this PR?
There are often performance optimisations made available when using `NODE_ENV=production`, plus it ensures we use correct configuration for the particular environment e.g. `knex` production config (uses connection pooling) whereas it does not use connection pooling when `NODE_ENV` is set to `development`.

### How to review 
Run the application using eq-compose.
Ensure that the `eq-author-api` and `eq-publisher` are running with the `NODE_ENV` environment variable set to `production`.
  