### PR TITLE
Explicitly set what the key file is called

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,7 @@ services:
       EQ_RABBITMQ_HOST: rabbit
       EQ_RABBITMQ_HOST_SECONDARY: rabbit
       EQ_SECRETS_FILE: docker-secrets.yml
+      EQ_KEYS_FILE: docker-keys.yml
       EQ_DYNAMODB_ENDPOINT: http://eq-survey-runner-dynamodb:8000
       EQ_SUBMITTED_RESPONSES_TABLE_NAME: dev-submitted-responses
       EQ_QUESTIONNAIRE_STATE_TABLE_NAME: dev-questionnaire-state


### PR DESCRIPTION
I had an issue earlier where master was working, but when pulling a specific survey-runner image it wouldn't run with the following message:
```
eq-survey-runner_1           |   File "/usr/src/app/app/setup.py", line 72, in create_app
eq-survey-runner_1           |     with open(application.config['EQ_KEYS_FILE']) as keys_file:
```

I don't know how it was working before as it wasn't being set explicitly.
This should fix it so that it doesn't happen again.
