### PR TITLE
Update docker compose config to use new launch mechanism

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,15 +108,13 @@ services:
       REACT_APP_BASE_NAME: /eq-author
       REACT_APP_API_URL: http://localhost:4000/graphql
       REACT_APP_USE_MOCK_API: "false"
-      REACT_APP_PUBLISHER_URL: http://eq-publisher:9000/publish
-      REACT_APP_GO_LAUNCH_A_SURVEY_URL: http://localhost:8000/quick-launch
+      REACT_APP_LAUNCH_URL: http://localhost:4000/launch
       REACT_APP_ENABLE_AUTH: "${AUTHOR_ENABLE_AUTH:-false}"
       REACT_APP_FIREBASE_PROJECT_ID: "${AUTHOR_FIREBASE_PROJECT_ID:-FAKE_ID}"
       REACT_APP_FIREBASE_API_KEY: "${AUTHOR_FIREBASE_API_KEY:-FAKE_API_KEY}"
       REACT_APP_FIREBASE_MESSAGING_SENDER_ID: "${AUTHOR_FIREBASE_MESSAGING_SENDER_ID:-FAKE_SENDER_ID}"
     depends_on:
       - eq-author-api
-      - eq-survey-launcher
     restart: always
     networks:
       - eq-author
@@ -127,6 +125,8 @@ services:
     image: onsdigital/eq-author-api
     environment:
       DB_CONNECTION_URI: postgres://postgres:mysecretpassword@eq-author-db:5432/postgres
+      RUNNER_SESSION_URL: http://localhost:5000/session?token=
+      PUBLISHER_URL: http://eq-publisher:9000/publish/
     depends_on:
       - eq-author-db
     restart: always


### PR DESCRIPTION
### Description

Author has introduced a new launch mechanism in order to remove it's dependency on go-launch-a-survey and to enable ongoing work to allow piping of metadata into questionnaires.

This change updates the existing eq-compose configuration with new environment variables to leverage this new launch mechanism.

### How to test

 - `docker-compose up`
 - Navigate to `localhost:3000`
 - Build a simple questionnaire
 - Observe that the preview link should use the new `/launch` URL.
 - Try to launch (preview)
 - Should display the questionnaire in runner.